### PR TITLE
#5 Query tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ e.g.:
 ```
 APP_ICNDB_URL=https://api.icndb.com
 LOGGING_LEVEL_feign=DEBUG
+LOGGING_LEVEL_graphql=DEBUG
 ```
 
 2.1. Run

--- a/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentation.java
+++ b/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentation.java
@@ -1,0 +1,42 @@
+
+package lv.ctco.tpl.bff.configuration;
+
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.tracing.TracingInstrumentation;
+import graphql.execution.instrumentation.tracing.TracingSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+@Component
+public class GraphqlTracingInstrumentation extends TracingInstrumentation {
+
+    private static final Logger logger = Logger.getLogger(GraphqlTracingInstrumentation.class.getSimpleName());
+
+    @Override
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
+        TracingSupport tracingSupport = parameters.getInstrumentationState();
+        String operationsName = getOperationsName(parameters);
+        logger.info(String.format("Query (%s) Execution time : %sms", operationsName, getTime(tracingSupport.snapshotTracingData())));
+        logger.info(String.format("Query (%s) : %s", operationsName, parameters.getQuery()));
+        logger.info(String.format("Query (%s) Variables : %s", operationsName, parameters.getVariables()));
+        return super.instrumentExecutionResult(executionResult, parameters);
+    }
+
+    private String getOperationsName(InstrumentationExecutionParameters parameters) {
+        return parameters.getOperation() != null ? parameters.getOperation() : UUID.randomUUID().toString();
+    }
+
+    private Long getTime(Map<String, Object> tracingData) {
+        if (tracingData != null && tracingData.containsKey("duration")) {
+            return TimeUnit.MILLISECONDS.convert((long) tracingData.get("duration"), TimeUnit.NANOSECONDS);
+        }
+        return null;
+    }
+
+}

--- a/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentation.java
+++ b/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentation.java
@@ -8,7 +8,6 @@ import graphql.execution.instrumentation.tracing.TracingSupport;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -16,25 +15,21 @@ import java.util.logging.Logger;
 @Component
 public class GraphqlTracingInstrumentation extends TracingInstrumentation {
 
-    private static final Logger logger = Logger.getLogger(GraphqlTracingInstrumentation.class.getSimpleName());
+    private static final String DURATION = "duration";
+    private final Logger log = Logger.getLogger(GraphqlTracingInstrumentation.class.getSimpleName());
 
     @Override
-    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult,
+                                                                        InstrumentationExecutionParameters parameters) {
         TracingSupport tracingSupport = parameters.getInstrumentationState();
-        String operationsName = getOperationsName(parameters);
-        logger.info(String.format("Query (%s) Execution time : %sms", operationsName, getTime(tracingSupport.snapshotTracingData())));
-        logger.info(String.format("Query (%s) : %s", operationsName, parameters.getQuery()));
-        logger.info(String.format("Query (%s) Variables : %s", operationsName, parameters.getVariables()));
+        Long executionTime = getTime(tracingSupport.snapshotTracingData());
+        log.info(String.format("Query (%s) Execution time : %sms", parameters.getOperation(), executionTime));
         return super.instrumentExecutionResult(executionResult, parameters);
     }
 
-    private String getOperationsName(InstrumentationExecutionParameters parameters) {
-        return parameters.getOperation() != null ? parameters.getOperation() : UUID.randomUUID().toString();
-    }
-
     private Long getTime(Map<String, Object> tracingData) {
-        if (tracingData != null && tracingData.containsKey("duration")) {
-            return TimeUnit.MILLISECONDS.convert((long) tracingData.get("duration"), TimeUnit.NANOSECONDS);
+        if (tracingData != null && tracingData.containsKey(DURATION)) {
+            return TimeUnit.MILLISECONDS.convert((long) tracingData.get(DURATION), TimeUnit.NANOSECONDS);
         }
         return null;
     }

--- a/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentationConfiguration.java
+++ b/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentationConfiguration.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @Component
-@Slf4j
+@Slf4j(topic = "graphql")
 public class GraphqlTracingInstrumentationConfiguration extends TracingInstrumentation {
 
     private static final String DURATION = "duration";

--- a/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentationConfiguration.java
+++ b/api/src/main/java/lv/ctco/tpl/bff/configuration/GraphqlTracingInstrumentationConfiguration.java
@@ -5,26 +5,34 @@ import graphql.ExecutionResult;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.tracing.TracingInstrumentation;
 import graphql.execution.instrumentation.tracing.TracingSupport;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 @Component
-public class GraphqlTracingInstrumentation extends TracingInstrumentation {
+@Slf4j
+public class GraphqlTracingInstrumentationConfiguration extends TracingInstrumentation {
 
     private static final String DURATION = "duration";
-    private final Logger log = Logger.getLogger(GraphqlTracingInstrumentation.class.getSimpleName());
 
     @Override
     public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult,
                                                                         InstrumentationExecutionParameters parameters) {
+        if (log.isDebugEnabled()) {
+            logTracingResults(parameters);
+        }
+        return super.instrumentExecutionResult(executionResult, parameters);
+    }
+
+    private void logTracingResults(InstrumentationExecutionParameters parameters) {
         TracingSupport tracingSupport = parameters.getInstrumentationState();
         Long executionTime = getTime(tracingSupport.snapshotTracingData());
-        log.info(String.format("Query (%s) Execution time : %sms", parameters.getOperation(), executionTime));
-        return super.instrumentExecutionResult(executionResult, parameters);
+        if (executionTime != null) {
+            log.debug(String.format("Query (%s) Execution time : %s ms", parameters.getOperation(), executionTime));
+        }
     }
 
     private Long getTime(Map<String, Object> tracingData) {


### PR DESCRIPTION
Output example

```
2017-11-02 16:42:07.530  INFO 14368 --- [  XNIO-2 task-1] GraphqlTracingInstrumentation            : Query (example) Execution time : 56ms
2017-11-02 16:42:07.530  INFO 14368 --- [  XNIO-2 task-1] GraphqlTracingInstrumentation            : Query (example) : query example($id:String){
  ping
  jokes{
    jokeByCategory(request: {category: NERDY}){
      id
      text
    }
    jokeById(id: $id){
      id
      text
    }
  }
}

2017-11-02 16:42:07.530  INFO 14368 --- [  XNIO-2 task-1] GraphqlTracingInstrumentation            : Query (example) Variables : {id=1}

```